### PR TITLE
Get N deposition and leaching from CLM history files(and Remove LITFALL)

### DIFF
--- a/src/fluxMod.f90
+++ b/src/fluxMod.f90
@@ -20,6 +20,15 @@ module fluxMod
       stop
     end if
   end function set_N_dep
+  
+  function calc_Leaching(drain,h2o_tot, N_inorganic) result(Leach)
+    real(r8)           :: Leach       !gN/m3 s
+    real(r8)           :: drain       !mmH20/s = kgH20/m2 s
+    real(r8)           :: h2o_tot     !kgH20/m2
+    real(r8)           :: N_inorganic !gN/m3
+    Leach = N_inorganic*drain/h2o_tot
+  end function calc_Leaching
+
 
   function MMK_flux(C_SAP,C_SUBSTRATE,MMK_nr) result(flux)
     !Compute C flux from substrate pool to saprotroph pool by using Michaelis Menten Kinetics.
@@ -188,9 +197,6 @@ module fluxMod
     !Transport from SOMc to SOMa:
     N_SOMcSOMa = C_SOMcSOMa*N_SOMc/C_SOMc
 
-    !Leaching based on Baskaran et al leaching rate:
-    Leaching=L_rate*N_IN
-
     !All N the Mycorrhiza dont need for its own, it gives to the plant:
     N_EcMPlant = N_INEcM + N_SOMpEcM + N_SOMcEcM - e_m*(1-enzyme_pct)*C_PlantEcM/CN_ratio(5)  !gN/m3h
     if ( N_EcMPlant .LT. 0.) then
@@ -306,23 +312,21 @@ module fluxMod
   end subroutine moisture_func
 
   subroutine input_rates(layer_nr,&
-                                  TOTC_LITFALL,LEAFC_TO_LIT,FROOTC_TO_LIT,LEAFN_TO_LIT,FROOTN_TO_LIT, &
-                                  C_EcMinput,N_LEACHinput,&
+                                  LEAFC_TO_LIT,FROOTC_TO_LIT,LEAFN_TO_LIT,FROOTN_TO_LIT, &
+                                  C_EcMinput,&
                                   N_CWD,C_CWD, &
                                   C_PlantLITm,C_PlantLITs,&
                                   N_PlantLITm,N_PlantLITs,&
-                                  N_LEACH,C_PlantEcM,C_PlantAM)
+                                  C_PlantEcM,C_PlantAM)
 
     !NOTE: Which and how many layers that receives input from the "outside" (CLM history file) is hardcoded here. This may change in the future.
     !in:
     integer,  intent(in) :: layer_nr
-    real(r8), intent(in) :: TOTC_LITFALL
     real(r8), intent(in) :: LEAFC_TO_LIT
     real(r8), intent(in) :: FROOTC_TO_LIT
     real(r8), intent(in) :: LEAFN_TO_LIT
     real(r8), intent(in) :: FROOTN_TO_LIT    
     real(r8), intent(in) :: C_EcMinput
-    real(r8), intent(in) :: N_LEACHinput(:)
     real(r8), intent(in) :: N_CWD(:)
     real(r8), intent(in) :: C_CWD(:)
     
@@ -331,7 +335,6 @@ module fluxMod
     real(r8), intent(out) :: C_PlantLITs
     real(r8), intent(out) :: N_PlantLITm
     real(r8), intent(out) :: N_PlantLITs
-    real(r8), intent(out) :: N_LEACH
     real(r8), intent(out) :: C_PlantEcM
     real(r8), intent(out) :: C_PlantAM
     

--- a/src/paramMod.f90
+++ b/src/paramMod.f90
@@ -80,7 +80,6 @@ real(r8), parameter :: Km_myc = 0.08            ![gNm-2] Half saturation constan
 real(r8), parameter :: V_max_myc = 1.8/hr_pr_yr  ![g g-1 hr-1] Max mycorrhizal uptake of inorganic N (called K_mn in article) 
 real(r8), parameter :: e_m = 0.25             !Growth efficiency of mycorrhiza 
 
-real(r8)            :: L_rate        ![1/ hr] Leaching rate 
 
 !Decomposition rates:
 real(r8), parameter :: K_MO = 0.003/hr_pr_yr ![m2gC-1hr-1] Mycorrhizal decay rate constant for oxidizable store     NOTE: vary from 0.0003 to 0.003 in article

--- a/src/readMod.f90
+++ b/src/readMod.f90
@@ -92,16 +92,15 @@ module readMod
       
                   
       subroutine read_clm_model_input(ncid, nlevdecomp,time_entry, &
-                                      LITFALL, LEAFN_TO_LITTER,FROOTN_TO_LITTER, NPP_NACTIVE,NDEP_TO_SMINN, &
+                                      LEAFN_TO_LITTER,FROOTN_TO_LITTER, NPP_NACTIVE,NDEP_TO_SMINN, &
                                       LEAFC_TO_LITTER,FROOTC_TO_LITTER,mcdate,TSOI,SOILLIQ,SOILICE, &
-                                      W_SCALAR,C_CWD,N_CWD,N_leach)
+                                      W_SCALAR,QDRAI,h2o_liq_tot,C_CWD,N_CWD)
         !INPUT
         integer,intent(in)            :: ncid
         integer,intent(in)            :: nlevdecomp          
         integer,intent(in)            :: time_entry
           
         !OUTPUT 
-        real(r8),intent(out)                                :: LITFALL      !litterfall (leaves and fine roots)  [gC/m^2/hour] (converted from [gC/m^2/s])  
         real(r8),intent(out)                                :: LEAFN_TO_LITTER !litterfall N from leaves  [gN/m^2/hour] (converted from [gN/m^2/s])      
         real(r8),intent(out)                                :: FROOTN_TO_LITTER !litterfall N from leaves  [gN/m^2/hour] (converted from [gN/m^2/s])                    
         real(r8),intent(out)                                :: NPP_NACTIVE  !Mycorrhizal N uptake used C        [gC/m^2/hour] (converted from [gC/m^2/s])  
@@ -110,13 +109,13 @@ module readMod
         real(r8),intent(out)                                :: FROOTC_TO_LITTER
         integer ,intent(out)                                :: mcdate  !"Current date" , end of averaging interval
         real(r8),intent(out),dimension(nlevdecomp)          :: TSOI    !Celcius
-        real(r8),intent(out),dimension(nlevdecomp)          :: SOILLIQ !m3/m3
-        real(r8),intent(out),dimension(nlevdecomp)          :: SOILICE !m3/m3
-        real(r8),intent(out),dimension(nlevdecomp)          :: W_SCALAR          
+        real(r8),intent(out),dimension(nlevdecomp)          :: SOILLIQ !m3/m3 (converted from kg/m2)
+        real(r8),intent(out),dimension(nlevdecomp)          :: SOILICE !m3/m3 (converted from kg/m2)
+        real(r8),intent(out),dimension(nlevdecomp)          :: W_SCALAR     
+        real(r8),intent(out)                                :: QDRAI   !kgH20/m2
+        real(r8),intent(out)                                :: h2o_liq_tot
         real(r8),intent(out)                                :: C_CWD(:) !gC/(m3 h)
         real(r8),intent(out)                                :: N_CWD(:) !gN/(m3 h)
-        real(r8),intent(out)                                :: N_leach(:)
-
 
           !Local
         integer                   :: varid
@@ -126,6 +125,7 @@ module readMod
         real(r8)                    :: N_CWD2(nlevdecomp)
         real(r8)                    :: N_CWD3(nlevdecomp)                  
           
+        
         call check(nf90_inq_varid(ncid, 'CWDC_TO_LITR2C_vr', varid))
         call check(nf90_get_var(ncid, varid, C_CWD2, start=(/1,1,time_entry/),count=(/1,nlevdecomp,1/)))
         C_CWD2=C_CWD2*sec_pr_hr !gC/(m3 s) to gC/(m3 h)
@@ -143,40 +143,41 @@ module readMod
         call check(nf90_get_var(ncid, varid, N_CWD3, start=(/1,1,time_entry/),count=(/1,nlevdecomp,1/)))
         N_CWD3=N_CWD3*sec_pr_hr !gN/(m3 s) to gN/(m3 h)        
         N_CWD=N_CWD2+N_CWD3
-          call check(nf90_inq_varid(ncid, 'LITFALL', varid))
-          call check(nf90_get_var(ncid, varid, LITFALL,start=(/1, time_entry/)))
-          LITFALL = LITFALL*sec_pr_hr  ![gC/m^2/h]
-          
-          call check(nf90_inq_varid(ncid, 'LEAFN_TO_LITTER', varid))
-          call check(nf90_get_var(ncid, varid, LEAFN_TO_LITTER,start=(/1, time_entry/)))
-          LEAFN_TO_LITTER = LEAFN_TO_LITTER*sec_pr_hr  ![gC/m^2/h]
-          
-          call check(nf90_inq_varid(ncid, 'FROOTN_TO_LITTER', varid))
-          call check(nf90_get_var(ncid, varid, FROOTN_TO_LITTER,start=(/1, time_entry/)))
-          FROOTN_TO_LITTER = FROOTN_TO_LITTER*sec_pr_hr  ![gC/m^2/h]          
+        
+        call check(nf90_inq_varid(ncid, 'LEAFN_TO_LITTER', varid))
+        call check(nf90_get_var(ncid, varid, LEAFN_TO_LITTER,start=(/1, time_entry/)))
+        LEAFN_TO_LITTER = LEAFN_TO_LITTER*sec_pr_hr  ![gC/m^2/h]
+        
+        call check(nf90_inq_varid(ncid, 'FROOTN_TO_LITTER', varid))
+        call check(nf90_get_var(ncid, varid, FROOTN_TO_LITTER,start=(/1, time_entry/)))
+        FROOTN_TO_LITTER = FROOTN_TO_LITTER*sec_pr_hr  ![gC/m^2/h]          
 
-          call check(nf90_inq_varid(ncid, 'NPP_NACTIVE', varid))
-          call check(nf90_get_var(ncid, varid, NPP_NACTIVE,start=(/1, time_entry/)))
-          NPP_NACTIVE = NPP_NACTIVE*sec_pr_hr ![gC/m^2/h]
+        call check(nf90_inq_varid(ncid, 'NPP_NACTIVE', varid))
+        call check(nf90_get_var(ncid, varid, NPP_NACTIVE,start=(/1, time_entry/)))
+        NPP_NACTIVE = NPP_NACTIVE*sec_pr_hr ![gC/m^2/h]
 
-          call check(nf90_inq_varid(ncid, 'NDEP_TO_SMINN', varid))
-          call check(nf90_get_var(ncid, varid, NDEP_TO_SMINN,start=(/1, time_entry/)))
-          NDEP_TO_SMINN = NDEP_TO_SMINN*sec_pr_hr ![gN/m^2/h]
+        call check(nf90_inq_varid(ncid, 'NDEP_TO_SMINN', varid))
+        call check(nf90_get_var(ncid, varid, NDEP_TO_SMINN,start=(/1, time_entry/)))
+        NDEP_TO_SMINN = NDEP_TO_SMINN*sec_pr_hr ![gN/m^2/h]
 
-          call check(nf90_inq_varid(ncid, 'LEAFC_TO_LITTER', varid))
-          call check(nf90_get_var(ncid, varid, LEAFC_TO_LITTER,start=(/1, time_entry/)))          
-          LEAFC_TO_LITTER = LEAFC_TO_LITTER*sec_pr_hr  ![gC/m^2/h]
+        call check(nf90_inq_varid(ncid, 'LEAFC_TO_LITTER', varid))
+        call check(nf90_get_var(ncid, varid, LEAFC_TO_LITTER,start=(/1, time_entry/)))          
+        LEAFC_TO_LITTER = LEAFC_TO_LITTER*sec_pr_hr  ![gC/m^2/h]
 
-          call check(nf90_inq_varid(ncid, 'FROOTC_TO_LITTER', varid))
-          call check(nf90_get_var(ncid, varid, FROOTC_TO_LITTER,start=(/1, time_entry/)))          
-          FROOTC_TO_LITTER = FROOTC_TO_LITTER*sec_pr_hr  ![gC/m^2/h]
+        call check(nf90_inq_varid(ncid, 'FROOTC_TO_LITTER', varid))
+        call check(nf90_get_var(ncid, varid, FROOTC_TO_LITTER,start=(/1, time_entry/)))          
+        FROOTC_TO_LITTER = FROOTC_TO_LITTER*sec_pr_hr  ![gC/m^2/h]
 
 
+        call check(nf90_inq_varid(ncid, 'QDRAI', varid))
+        call check(nf90_get_var(ncid, varid, QDRAI,start=(/1, time_entry/)))    
 
-         call check(nf90_inq_varid(ncid, 'mcdate', varid))
-         call check(nf90_get_var(ncid, varid, mcdate, start=(/time_entry/)))
-         
-         call check(nf90_inq_varid(ncid, 'TSOI', varid))
+              
+        call check(nf90_inq_varid(ncid, 'mcdate', varid))
+        call check(nf90_get_var(ncid, varid, mcdate, start=(/1,time_entry/)))
+
+
+        call check(nf90_inq_varid(ncid, 'TSOI', varid))
          call check(nf90_get_var(ncid, varid, TSOI, start=(/1,1,time_entry/), count=(/1,nlevdecomp,1/)))
 
          call check(nf90_inq_varid(ncid, 'SOILLIQ', varid))
@@ -187,15 +188,18 @@ module readMod
 
          call check(nf90_inq_varid(ncid, 'W_SCALAR', varid))
          call check(nf90_get_var(ncid, varid, W_SCALAR, start=(/1,1,time_entry/), count=(/1,nlevdecomp,1/)))
+
          !Unit conversions:
          TSOI = TSOI - 273.15 !Kelvin to Celcius 
+         h2o_liq_tot=0.0
+         do i = 1, nlevdecomp ! Unit conversion
+           h2o_liq_tot=h2o_liq_tot+SOILLIQ(i)
+         end do          
          do i = 1, nlevdecomp ! Unit conversion
            SOILICE(i) = SOILICE(i)/(delta_z(i)*917) !kg/m2 to m3/m3 rho_ice=917kg/m3
            SOILLIQ(i) = SOILLIQ(i)/(delta_z(i)*1000) !kg/m2 to m3/m3 rho_liq=1000kg/m3
          end do          
-        call check(nf90_inq_varid(ncid, 'SMIN_NO3_LEACHED_vr', varid))
-        call check(nf90_get_var(ncid, varid, N_leach, start=(/1,1,time_entry/),count=(/1,nlevdecomp,1/)))
-        N_leach=N_leach*sec_pr_hr !gN/(m3 s) to gN/(m3 h)         
+        
        end subroutine read_clm_model_input
        
 


### PR DESCRIPTION
-  Created function to calculate Leaching based on [CTSM documentation](https://escomp.github.io/ctsm-docs/versions/release-clm5.0/html/tech_note/External_Nitrogen_Cycle/CLM50_Tech_Note_External_Nitrogen_Cycle.html#leaching-losses-of-nitrogen)
- Make sure Deposition is read
- remove LITFALL as this is no longer used.